### PR TITLE
feat: Allow multiple mergesources

### DIFF
--- a/controllers/annotations.go
+++ b/controllers/annotations.go
@@ -6,4 +6,6 @@ const (
 
 	mergeSourceFinalizerName = "config.cmmc.k8s.cash.app/merge-source-finalizer"
 	mergeTargetFinalizerName = "config.cmmc.k8s.cash.app/merge-target-finalizer"
+
+	separator = ","
 )


### PR DESCRIPTION
Append multiple mergesource's names to the annotation in the configmap
(separated with `,`) in order to allow multiple mergesource to target
the same configmap.

The use case is `mapRoles` and `mapUsers` for managing the `aws-auth`
config map.

Fix https://github.com/cashapp/cmmc/issues/7

(I tested it locally and `bappr/cmmc:v0.0.2` is running in my infra)