### PR TITLE
Initial documentation (and gh-pages)

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,16 @@
+name: mkdocs
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -5,38 +5,3 @@ of ConfigMap resources.
 
 Documentation at <https://cashapp.github.io/cmmc>.
 
-## Why?
-
-The impetus for building this is to have a GitOps friendly solution to manage
-`kube-system/aws-auth`, a ConfigMap that binds AWS roles to K8S Roles in EKS ([link][1]).
-
-Instead of solving the problem directly, the approach was to ask the question:
-
-> If another tool existed that would make this problem trivial to solve that wasn't
-> just for _this specific use-case_, what would it be?
-
-[See the demo for managing `kube-system/aws-auth` here](/example/aws-auth).
-
-## Features
-
-- Watch specific keys of ConfigMaps and merge their results into a target.
-- Changes to resources are non-destructive and recoverable
-- Permissions gated by namespace selectors
-- JSON Schema Validation for the target ConfigMap (possibly add other validation in the future).
-- Fully Configurable source/target selectors mix and match
-- Metrics exposed for how many resources are being watched/updated, and their states.
-
-## Usage
-
-- [See usage & deployment docs](/usage).
-- Resource reference: [`MergeSource`](/resources/mergesource), [`MergeTarget`](/resources/mergetarget).
-
-## Contributing
-
-[See contributing docs](/contributing).
-
-## License
-
-Apache Licnese 2.0
-
-[1]: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html

--- a/README.md
+++ b/README.md
@@ -1,235 +1,42 @@
 # ConfigMap Merging Controller (cmmc)
 
-`cmmc` is a k8s operator that allows for the merging of ConfigMap resources with data validation.
+`CMMC` is a Kubernetes operator that allows for the combination
+of ConfigMap resources.
+
+Documentation at <https://cashapp.github.io/cmmc>.
 
 ## Why?
 
 The impetus for building this is to have a GitOps friendly solution to manage
 `kube-system/aws-auth`, a ConfigMap that binds AWS roles to K8S Roles in EKS ([link][1]).
 
-Instead of solving the problem directly, our approach was to ask the question: 
-If another tool existed that would make this problem trivial to solve that wasn't
-specific to _this specific use-case_, what would it be?
+Instead of solving the problem directly, the approach was to ask the question:
+
+> If another tool existed that would make this problem trivial to solve that wasn't
+> just for _this specific use-case_, what would it be?
+
+[See the demo for managing `kube-system/aws-auth` here](/example/aws-auth).
 
 ## Features
 
 - Watch specific keys of ConfigMaps and merge their results into a target.
-- JSON Schema Validation for the target ConfigMap (possibly add other validation in the future).
-- Fully Configurable source/target selectors mix and match 
 - Changes to resources are non-destructive and recoverable
-- Permissions gated by namespace selectors (if desired)
+- Permissions gated by namespace selectors
+- JSON Schema Validation for the target ConfigMap (possibly add other validation in the future).
+- Fully Configurable source/target selectors mix and match
 - Metrics exposed for how many resources are being watched/updated, and their states.
 
-## How
+## Usage
 
-The operator is built on the [kubebuilder][2] library and has two controllers/reconcilers, 
-one for the `MergeSource` resource and one for `MergeTarget`.
+- [See usage & deployment docs](/usage).
+- Resource reference: [`MergeSource`](/resources/mergesource), [`MergeTarget`](/resources/mergetarget).
 
-### Resources & Configuration
+## Contributing
 
-#### `MergeSource`
+[See contributing docs](/contributing).
 
-```yaml
-apiVersion: config.cmmc.k8s.cash.app/v1beta1
-kind: MergeSource
-metadata:
-  name: merge-map-roles-aws-auth
-spec:
-  selector: 
-    cmmc.k8s.cash.app/merge: "something"
-  source:
-    data: someKey
-  target: 
-    name: our-merge-target
-    data: someKey
-```
+## License
 
-- A `MergeSource` describes what `ConfigMap` resource we are watching with its `selector` field.   
-  So any `ConfigMap` with a label that matches `spec.selector` will be watched.
-- The controller will read data from the `source.data` field on a matching `ConfigMap`
-- The `MergeSource` will annotate the watched CMs so they know they are being watched.
-- _This resource/controller does no mutatations of the data on any of the resources outside of
-  the annotation!_
-- Annotations are cleaned up when the resource is deleted.
-- The MergeTarget at `spec.target.name` will watch for `MergeSource` resources with it as the target
-  and read their aggregated states to attempt to write to the target ConfigMap.
-
-#### `MergeTarget`
-
-```yaml
-apiVersion: config.cmmc.k8s.cash.app/v1beta1
-kind: MergeTarget
-metadata:
-  name: our-merge-target
-spec:
-  target: some-ns/some-resource-name # a configMap
-  data:
-    someKey: 
-      init: ''
-      jsonSchema: |
-        { … }
-```
-
-- A `MergeTarget` describes the resource we are managing, in this case it is `some-ns/some-resource-name`.
-- We can configure this resource with the keys that we care about managing on the target, above
-  its `someKey`.
-- Each `data[$key]` 
-  - Can have an initial value that we'll inject _if the data was not present_ the key was missing or empty
-  - Can have an optional `jsonSchema` that we use to validate the data _before it is persisted_.
-- Creates the ConfigMap if it doesn't exist.
-- Uses annotations to make sure there is only one `MergeTarget` per `spec.target`
-- Clean up after itself when it is deleted.
-  - If it didn't eist, it will be removed
-  - If it did exist, the data will be reset back to what it was before.
-
-## Demo (aws-auth)
-
-Let's build a solution for managing `kube-system/aws-auth`.
-
-#### 1. Create a `MergeTarget`
-
-A `MergeTarget` describes the target `ConfigMap` that want to write the data to.
-
-```sh
-cat <<EOF | kubectl apply -f -
-apiVersion: config.cmmc.k8s.cash.app/v1beta1
-kind: MergeTarget
-metadata:
-  name: kube-system-aws-auth
-spec:
-  target: kube-system/aws-auth
-  data:
-    mapRoles: {}
-    mapUsers: {}
-EOF
-```
-
-This says that we want to write/merge data to the `mapRoles` and `mapUsers` keys
-of `kube-system/aws-auth`. Note, there is no auth, or initial value for these keys
-in this example, but we can add this later on.
-
-#### 2. Create a `MergeSource` for `mapRoles`
-
-A `MergeSource` describes what `ConfigMap`s we are watching to write to the `target`. 
-This one specifically looks for ConfigMap resources with the label:
-`cmmc:k8s.cash.app/merge: "aws-auth-map-roles"`.
-
-__`target.name`__ refers to the `MergeTarget` we created earlier.
-
-```sh
-cat <<EOF | kubectl apply -f -
-apiVersion: config.cmmc.k8s.cash.app/v1beta1
-kind: MergeSource
-metadata:
-  name: aws-auth-map-roles
-spec:
-  selector:
-    cmmc.k8s.cash.app/merge: "aws-auth-map-roles"
-  source:
-    data: mapRoles
-  target:
-    name: kube-system-aws-auth 
-    data: mapRoles
-EOF
-```
-
-#### 3. Create some sample ConfigMap sources
-
-Let's create a sample configuration for two services/namespaces, `service-a` and `service-b`,
-which need some role binding from AWS to K8S.
-
-```sh
-cat <<EOF | kubectl apply -f -
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: service-a
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: service-b
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: aws-roles-mapping
-  namespace: service-a
-  labels:
-    cmmc.k8s.cash.app/merge: "aws-auth-map-roles"
-data:
-  mapRoles: |
-    - arn: arn:aws:iam::111122223333:role/external-user-service-a
-      username: service-a-external
-      groups:
-      - service-a
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: aws-roles-mapping
-  namespace: service-b
-  labels:
-    cmmc.k8s.cash.app/merge: "aws-auth-map-roles"
-data:
-  mapRoles: |
-    - arn: arn:aws:iam::111122223333:role/external-user-service-b
-      username: service-b-external
-      groups:
-      - service-b
-EOF
-```
-
-#### 4. Check the resources 
-
-##### Target
-
-```sh
-kubectl get cm -n kube-system aws-auth -o yaml
-```
-
-```yaml
-apiVersion: v1
-data:
-  mapRoles: |
-    - arn: arn:aws:iam::111122223333:role/external-user-service-b
-      username: service-b-external
-      groups:
-      - service-b
-    - arn: arn:aws:iam::111122223333:role/external-user-service-a
-      username: service-a-external
-      groups:
-      - service-a
-kind: ConfigMap
-metadata:
-  annotations:
-    config.cmmc.k8s.cash.app/managed-by-merge-target: default/kube-system-aws-auth
-  name: aws-auth
-  namespace: kube-system
-```
-
-##### Statuses
-
-```
-# kubectl get mergetarget
-NAME                   TARGET                 READY   STATUS                         VALIDATION
-kube-system-aws-auth   kube-system/aws-auth   True    Target ConfigMap up to date.   1 MergeSources reporting valid data
-```
-
-```
-# kubectl get mergesource
-NAME                 READY   STATUS
-aws-auth-map-roles   True    Data from 2 ConfigMap(s)
-```
-
-### Cleanup
-
-```sh
-kubectl delete ns service-a
-kubectl delete ns service-b
-kubectl delete mergesource aws-auth-map-roles
-kubectl delete mergetarget kube-system-aws-auth
-```
+Apache Licnese 2.0
 
 [1]: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
-[2]: https://book.kubebuilder.io/

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,3 @@
+# Architecture
+
+TODO

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,27 @@
+# Contributing
+
+The operator is built on the [kubebuilder][1] library and has two controllers/reconcilers,
+one for the `MergeSource` resource and one for `MergeTarget`.
+
+```sh
+git clone git@github.com:cashapp/cmmc.git
+cd cmmc
+```
+
+## Running locally
+
+You can run a local build of the operator and point it at whatever cluster you
+want.
+
+```sh
+make install
+make run
+```
+
+## Running tests locally
+
+```sh
+make test
+```
+
+[1]: https://book.kubebuilder.io/

--- a/docs/example/aws-auth.md
+++ b/docs/example/aws-auth.md
@@ -1,0 +1,150 @@
+# aws-auth
+
+Let's build a solution for managing [`kube-system/aws-auth`][1].
+
+## 1. Create a `MergeTarget`
+
+A `MergeTarget` describes the target `ConfigMap` that want to write the data to.
+
+```sh
+cat <<EOF | kubectl apply -f -
+apiVersion: config.cmmc.k8s.cash.app/v1beta1
+kind: MergeTarget
+metadata:
+  name: kube-system-aws-auth
+spec:
+  target: kube-system/aws-auth
+  data:
+    mapRoles: {}
+    mapUsers: {}
+EOF
+```
+
+This says that we want to write/merge data to the `mapRoles` and `mapUsers` keys
+of `kube-system/aws-auth`. Note, there is no validation, or initial value for these keys
+in this example, but we can add this later on.
+
+## 2. Create a `MergeSource` for `mapRoles`
+
+A `MergeSource` describes what `ConfigMap`s we are watching to write to the `target`.
+This one specifically looks for ConfigMap resources with the label:
+`cmmc:k8s.cash.app/merge: "aws-auth-map-roles"`.
+
+__`target.name`__ refers to the `MergeTarget` we created earlier.
+
+```sh
+cat <<EOF | kubectl apply -f -
+apiVersion: config.cmmc.k8s.cash.app/v1beta1
+kind: MergeSource
+metadata:
+  name: aws-auth-map-roles
+spec:
+  selector:
+    cmmc.k8s.cash.app/merge: "aws-auth-map-roles"
+  source:
+    data: mapRoles
+  target:
+    name: kube-system-aws-auth
+    data: mapRoles
+EOF
+```
+
+## 3. Create some sample ConfigMap sources
+
+Let's create a sample configuration for two services/namespaces, `service-a` and `service-b`,
+which need some role binding from AWS to K8S.
+
+```sh
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: service-a
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: service-b
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-roles-mapping
+  namespace: service-a
+  labels:
+    cmmc.k8s.cash.app/merge: "aws-auth-map-roles"
+data:
+  mapRoles: |
+    - arn: arn:aws:iam::111122223333:role/external-user-service-a
+      username: service-a-external
+      groups:
+      - service-a
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-roles-mapping
+  namespace: service-b
+  labels:
+    cmmc.k8s.cash.app/merge: "aws-auth-map-roles"
+data:
+  mapRoles: |
+    - arn: arn:aws:iam::111122223333:role/external-user-service-b
+      username: service-b-external
+      groups:
+      - service-b
+EOF
+```
+
+## 4. Check the resources
+
+### Target
+
+```sh
+kubectl get cm -n kube-system aws-auth -o yaml
+```
+
+```yaml
+apiVersion: v1
+data:
+  mapRoles: |
+    - arn: arn:aws:iam::111122223333:role/external-user-service-b
+      username: service-b-external
+      groups:
+      - service-b
+    - arn: arn:aws:iam::111122223333:role/external-user-service-a
+      username: service-a-external
+      groups:
+      - service-a
+kind: ConfigMap
+metadata:
+  annotations:
+    config.cmmc.k8s.cash.app/managed-by-merge-target: default/kube-system-aws-auth
+  name: aws-auth
+  namespace: kube-system
+```
+
+### Statuses
+
+```
+# kubectl get mergetarget
+NAME                   TARGET                 READY   STATUS                         VALIDATION
+kube-system-aws-auth   kube-system/aws-auth   True    Target ConfigMap up to date.   1 MergeSources reporting valid data
+```
+
+```
+# kubectl get mergesource
+NAME                 READY   STATUS
+aws-auth-map-roles   True    Data from 2 ConfigMap(s)
+```
+
+## Cleanup
+
+```sh
+kubectl delete ns service-a
+kubectl delete ns service-b
+kubectl delete mergesource aws-auth-map-roles
+kubectl delete mergetarget kube-system-aws-auth
+```
+
+[1]: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html

--- a/docs/example/jsonschema.md
+++ b/docs/example/jsonschema.md
@@ -1,0 +1,53 @@
+# aws-auth JSONSchema
+
+These satisfy the kube-system/aws-auth definition for `mapUsers` and `mapRoles`.
+
+## mapRoles
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "aws-auth-map-roles",
+  "type": "array",
+  "items": { "$ref": "#/$defs/role" },
+  "$defs": {
+    "role": {
+      "type": "object",
+      "required": [ "rolearn", "username", "groups" ],
+      "properties":  {
+        "rolearn": {
+          "type": "string",
+          "pattern": "^arn:aws:iam::\\d+:role/.+"
+        },
+        "username": { "type": "string" },
+        "groups": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}
+```
+
+## mapUsers
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "aws-auth-map-users",
+  "type": "array",
+  "items": { "$ref": "#/$defs/user" },
+  "$defs": {
+    "user": {
+      "type": "object",
+      "required": [ "userarn", "username", "groups" ],
+      "properties":  {
+        "userarn": {
+          "type": "string",
+          "pattern": "^arn:aws:iam::\\d+:user/.+"
+        },
+        "username": { "type": "string" },
+        "groups": { "type": "array", "items": { "type": "string" } }
+      }
+    }
+  }
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+../README.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,35 @@
-../README.md
+# CMMC
+
+ConfigMap Merging Controller (cmmc) is a Kubernetes operator that allows for the combination
+of ConfigMap resources.
+
+## Why?
+
+The impetus for building this is to have a GitOps friendly solution to manage
+`kube-system/aws-auth`, a ConfigMap that binds [AWS roles to K8S Roles in EKS][1].
+Instead of solving the problem directly, the approach was to ask the question:
+_If another tool existed that would make this problem trivial to solve that wasn't
+just for this specific use-case what would it be?_
+
+- [Example for managing `kube-system/aws-auth`](/example/aws-auth).
+- [Usage & deployment docs](/usage).
+- Configuration reference: [`MergeSource`](/resources/mergesource), [`MergeTarget`](/resources/mergetarget).
+
+## Features
+
+- Watch specific keys of ConfigMaps and merge their results into a target ConfigMap.
+- Changes to existing resource state are non-destructive and recoverable.
+- JSONSchema validation capability to ensure that an invalid ConfigMap cannot be written.
+- Permissions optionally gated by namespace selectors.
+- Fully Configurable source/target selectors mix and match.
+- Metrics exposed for how many resources are being watched/updated, and their reconcile states.
+
+## Contributing
+
+[See contributing docs](/contributing).
+
+## License
+
+Apache Licnese 2.0
+
+[1]: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html

--- a/docs/resources/mergesource.md
+++ b/docs/resources/mergesource.md
@@ -1,0 +1,26 @@
+# MergeSource
+
+```yaml
+apiVersion: config.cmmc.k8s.cash.app/v1beta1
+kind: MergeSource
+metadata:
+  name: merge-map-roles-aws-auth
+spec:
+  selector:
+    cmmc.k8s.cash.app/merge: "something"
+  source:
+    data: someKey
+  target:
+    name: our-merge-target
+    data: someKey
+```
+
+- A `MergeSource` describes what `ConfigMap` resource we are watching with its `selector` field.
+  So any `ConfigMap` with a label that matches `spec.selector` will be watched.
+- The controller will read data from the `source.data` field on a matching `ConfigMap`
+- The `MergeSource` will annotate the watched CMs so they know they are being watched.
+- _This resource/controller does no mutatations of the data on any of the resources outside of
+  the annotation!_
+- Annotations are cleaned up when the resource is deleted.
+- The MergeTarget at `spec.target.name` will watch for `MergeSource` resources with it as the target
+  and read their aggregated states to attempt to write to the target ConfigMap.

--- a/docs/resources/mergetarget.md
+++ b/docs/resources/mergetarget.md
@@ -1,0 +1,28 @@
+# MergeTarget
+
+```yaml
+apiVersion: config.cmmc.k8s.cash.app/v1beta1
+kind: MergeTarget
+metadata:
+  name: our-merge-target
+spec:
+  target: some-ns/some-resource-name # a configMap
+  data:
+    someKey:
+      init: ''
+      jsonSchema: |
+        { … }
+```
+
+- A `MergeTarget` describes the resource we are managing, in this case it is `some-ns/some-resource-name`.
+- We can configure this resource with the keys that we care about managing on the target, above
+  its `someKey`.
+- Each `data[$key]`
+  - Can have an initial value that we'll inject _if the data was not present_ the key was missing or empty
+  - Can have an optional `jsonSchema` that we use to validate the data _before it is persisted_.
+- Creates the ConfigMap if it doesn't exist.
+- Uses annotations to make sure there is only one `MergeTarget` per `spec.target`
+- Clean up after itself when it is deleted.
+  - If it didn't eist, it will be removed
+  - If it did exist, the data will be reset back to what it was before.
+

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,50 @@
+# Usage
+
+## Installation
+
+* All of these [Kustomization][1] resources are located in the [`config/`][2] directory.
+* Each [release](https://github.com/cashapp/cmmc/releases) of cmmc is also pushed to [dockerhub](https://hub.docker.com/r/cashapp/cmmc/tags).
+
+!!! info cmmc version
+
+    Be sure to use the correct version of the operator and the resources!
+
+A very basic install of the operator involves installing the [CRDs], the permissions for the CMMC
+ServiceAccount to be able to watch and modify ConfigMaps, and the controller manager itself.
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: cmmc-system
+namePrefix: cmmc-
+
+images:
+- name: controller
+  newName: cashapp/cmmc
+  newTag: v0.0.2
+
+resources:
+- path/to/config/crd
+- path/to/config/rbac
+- path/to/config/manager
+```
+
+## Metrics
+
+You can also add a `PrometheusMonitor` to scrape the metrics by adding [`config/prometheus`][3]
+to the list.
+
+[FIXME][metrics-issue]
+
+## Custom Resources
+
+### MergeSource & MergeTarget
+
+See [`MergeTarget`](/resources/mergetarget) and [`MergeSource`](/resources/mergesource) docs.
+
+[1]: https://kubectl.docs.kubernetes.io/guides/introduction/
+[2]: https://github.com/cashapp/cmmc/tree/main/config
+[3]: https://github.com/cashapp/cmmc/blob/main/config/prometheus/monitor.yaml
+[crds]: https://github.com/cashapp/cmmc/tree/main/config/crds
+[metrics-issue]: https://github.com/cashapp/cmmc/issues/1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: cmmc
+site_name: ConfigMap Merging Controller
 repo_name: cashapp/cmmc
 repo_url: https://github.com/cashapp/cmmc
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,24 @@
+site_name: cmmc
+repo_name: cashapp/cmmc
+repo_url: https://github.com/cashapp/cmmc
+
+theme:
+  name: material
+  palette:
+    primary: red
+    accent: blue
+  features:
+  - navigation.sections
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight:
+      use_pygments: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.critic
+  - pymdownx.caret
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.tilde


### PR DESCRIPTION
- Moves documentation out of readme to `docs/` directory 
- Adds mkdocs-material
- adds some documentation about installation, local hacking, testing