### PR TITLE
feat: adding flags for MaxConcurrentReconciles

### DIFF
--- a/controllers/mergesource_controller.go
+++ b/controllers/mergesource_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -310,10 +311,11 @@ func (r *MergeSourceReconciler) maybeRemoveWatchedAnnotation(
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *MergeSourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *MergeSourceReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	return errors.WithStack(
 		ctrl.NewControllerManagedBy(mgr).
 			For(&cmmcv1beta1.MergeSource{}).
+			WithOptions(opts).
 			Watches(
 				&source.Kind{Type: &corev1.ConfigMap{}},
 				watchReconciliationEventHandler(

--- a/controllers/mergetarget_controller.go
+++ b/controllers/mergetarget_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -317,7 +318,7 @@ func resourceStatusTargetIndexer(o client.Object) []string {
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *MergeTargetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *MergeTargetReconciler) SetupWithManager(mgr ctrl.Manager, opts controller.Options) error {
 	ctx := context.Background()
 	if err := mgr.GetFieldIndexer().IndexField(
 		ctx, &cmmcv1beta1.MergeSource{}, fieldIndexStatusTarget, resourceStatusTargetIndexer,
@@ -328,6 +329,7 @@ func (r *MergeTargetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return errors.WithStack(
 		ctrl.NewControllerManagedBy(mgr).
 			For(&cmmcv1beta1.MergeTarget{}).
+			WithOptions(opts).
 			Watches(
 				&source.Kind{Type: &corev1.ConfigMap{}},
 				watchReconciliationEventHandler(managedByMergeTarget.ParseObjectName),

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -38,6 +38,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -98,14 +99,14 @@ var _ = BeforeSuite(func() {
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
 		Recorder: recorder,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(k8sManager, controller.Options{})
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&MergeSourceReconciler{
 		Client:   k8sManager.GetClient(),
 		Scheme:   k8sManager.GetScheme(),
 		Recorder: recorder,
-	}).SetupWithManager(k8sManager)
+	}).SetupWithManager(k8sManager, controller.Options{})
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,12 +25,59 @@ namePrefix: cmmc-
 images:
 - name: controller
   newName: cashapp/cmmc
-  newTag: v0.0.2
+  newTag: SOME_VERSION
 
 resources:
 - path/to/config/crd
 - path/to/config/rbac
 - path/to/config/manager
+```
+
+### Customizing Arguments
+
+By default (if you're using the above kustomization), `cmmc` runs with the `--leader-select` flag.
+You can check [`main.go`][main] for available args or run `go run ./ --help`.
+
+```
+Usage of cmmc:
+  -health-probe-bind-address string
+    	The address the probe endpoint binds to. (default ":8081")
+  -help
+    	Display usage
+  -kubeconfig string
+    	Paths to a kubeconfig. Only required if out-of-cluster.
+  -leader-elect
+    	Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.
+  -merge-source-max-concurrent-reconciles int
+    	MergeSourceController - MaxConcurrentReconciles (default 1)
+  -merge-target-max-concurrent-reconciles int
+    	MergeTargetController - MaxConcurrentReconciles (default 1)
+  -metrics-bind-address string
+    	The address the metric endpoint binds to. (default ":8080")
+  -zap-devel
+    	Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error) (default true)
+  -zap-encoder value
+    	Zap log encoding (one of 'json' or 'console')
+  -zap-log-level value
+    	Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
+  -zap-stacktrace-level value
+    	Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').
+```
+
+You can override any arguments by providing patches to the configuration above:
+
+```yaml
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/args
+      value: [
+        "--leader-select",
+        "--merge-target-max-concurrent-reconciles", "1",
+        "--merge-source-max-concurrent-reconciles", "2",
+      ]
+  target:
+    name: controller-manager
 ```
 
 ## Metrics
@@ -55,4 +102,4 @@ adding [`config/prometheus`][3] to the list.
 [2]: https://github.com/cashapp/cmmc/tree/main/config
 [3]: https://github.com/cashapp/cmmc/blob/main/config/prometheus/monitor.yaml
 [crds]: https://github.com/cashapp/cmmc/tree/main/config/crds
-[metrics-issue]: https://github.com/cashapp/cmmc/issues/1
+[main]: https://github.com/cashapp/cmmc/blob/main/main.go#L53

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -54,14 +55,25 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var mergeTargetMaxConcurrentReconciles int
+	var mergeSourceMaxConcurrentReconciles int
+	var displayHelp bool
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.IntVar(&mergeTargetMaxConcurrentReconciles, "merge-target-max-concurrent-reconciles", 1, "MergeTargetController - MaxConcurrentReconciles")
+	flag.IntVar(&mergeSourceMaxConcurrentReconciles, "merge-source-max-concurrent-reconciles", 1, "MergeSourceController - MaxConcurrentReconciles")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&displayHelp, "help", false, "Display usage")
 	opts := zap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if displayHelp {
+		flag.Usage()
+		os.Exit(0)
+	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
@@ -83,15 +95,20 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: recorder,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, controller.Options{
+		MaxConcurrentReconciles: mergeSourceMaxConcurrentReconciles,
+	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MergeSource")
 		os.Exit(1)
 	}
+
 	if err = (&controllers.MergeTargetReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: recorder,
-	}).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr, controller.Options{
+		MaxConcurrentReconciles: mergeSourceMaxConcurrentReconciles,
+	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MergeTarget")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Adding flags:
- `merge-source-max-concurrent-reconciles` (default 1)
- `merge-target-max-concurrent-reconciles` (default 1)
- `help` (prints help/usage)

Closes #6.