### PR TITLE
chore: deprecating namespace_selector

### DIFF
--- a/api/v1beta1/mergesource_types.go
+++ b/api/v1beta1/mergesource_types.go
@@ -52,11 +52,14 @@ type MergeSourceSpec struct {
 	// Selector specifies what labels on a source ConfigMap the controller will be watching.
 	Selector map[string]string `json:"selector,omitempty"`
 
+	// DeprecatedNamespaceSelector is deprecated in favor of NamespaceSelector.
+	DeprecatedNamespaceSelector map[string]string `json:"namespace_selector,omitempty"` //nolint:tagliatelle
+
 	// NamespaceSelector specifies what lables _must be_ on the source ConfigMaps namespace,
 	// (if any) for this to become a valid source.
 	//
 	// If omitted, will allow ConfigMaps from all namespaces.
-	NamespaceSelector map[string]string `json:"namespace_selector,omitempty"` //nolint:tagliatelle
+	NamespaceSelector map[string]string `json:"namespaceSelector,omitempty"`
 
 	// Source describes which data key from the source ConfigMap we will be observing/merging.
 	Source MergeSourceSourceSpec `json:"source,omitempty"`
@@ -83,6 +86,16 @@ type MergeSource struct {
 
 	Spec   MergeSourceSpec   `json:"spec,omitempty"`
 	Status MergeSourceStatus `json:"status,omitempty"`
+}
+
+// NamespaceSelector gives us the NamespaceSelector for the MergeSource,
+// respecting both the deprecated (underscore) field, and the other.
+func (m *MergeSource) NamespaceSelector() map[string]string {
+	if m.Spec.DeprecatedNamespaceSelector != nil {
+		return m.Spec.DeprecatedNamespaceSelector
+	}
+
+	return m.Spec.NamespaceSelector
 }
 
 // NamespacedTargetName gets the types.NamespacedName representation given the

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -110,6 +110,13 @@ func (in *MergeSourceSpec) DeepCopyInto(out *MergeSourceSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.DeprecatedNamespaceSelector != nil {
+		in, out := &in.DeprecatedNamespaceSelector, &out.DeprecatedNamespaceSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.NamespaceSelector != nil {
 		in, out := &in.NamespaceSelector, &out.NamespaceSelector
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/config.cmmc.k8s.cash.app_mergesources.yaml
+++ b/config/crd/bases/config.cmmc.k8s.cash.app_mergesources.yaml
@@ -48,6 +48,12 @@ spec:
               namespace_selector:
                 additionalProperties:
                   type: string
+                description: DeprecatedNamespaceSelector is deprecated in favor of
+                  NamespaceSelector.
+                type: object
+              namespaceSelector:
+                additionalProperties:
+                  type: string
                 description: "NamespaceSelector specifies what lables _must be_ on
                   the source ConfigMaps namespace, (if any) for this to become a valid
                   source. \n If omitted, will allow ConfigMaps from all namespaces."

--- a/controllers/mergesource_controller.go
+++ b/controllers/mergesource_controller.go
@@ -199,17 +199,18 @@ func (r *MergeSourceReconciler) sources(
 		return nil, nil
 	}
 
-	if len(s.Spec.NamespaceSelector) == 0 {
+	namespaceSelector := s.NamespaceSelector()
+	if len(namespaceSelector) == 0 {
 		return sources.Items, nil
 	}
 
 	var nsList corev1.NamespaceList
-	if err := r.List(ctx, &nsList, client.MatchingLabels(s.Spec.NamespaceSelector)); err != nil {
+	if err := r.List(ctx, &nsList, client.MatchingLabels(namespaceSelector)); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
 	if len(nsList.Items) == 0 {
-		log.FromContext(ctx).Info("[WARN] found no matching namespaces, filtering all configMaps", "selector", s.Spec.NamespaceSelector)
+		log.FromContext(ctx).Info("[WARN] found no matching namespaces, filtering all configMaps", "selector", namespaceSelector)
 		return nil, nil
 	}
 


### PR DESCRIPTION
Going forward from here, we should be using `namespaceSelector` instead. 

`MergeTarget.spec.namespace_selector` will be removed in a future version.