### PR TITLE
fix: pass the mergeTargetMaxConcurrentReconciles to the MergeTarget reconciler

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func main() { //nolint:funlen
 		Scheme:   mgr.GetScheme(),
 		Recorder: recorder,
 	}).SetupWithManager(mgr, controller.Options{
-		MaxConcurrentReconciles: mergeSourceMaxConcurrentReconciles,
+		MaxConcurrentReconciles: mergeTargetMaxConcurrentReconciles,
 	}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "MergeTarget")
 		os.Exit(1)


### PR DESCRIPTION
# Purpose

Was adjusting our `maxConcurrentReconciles` for the MergeSource controller and noticed MergeTarget was affected as well.