### PR TITLE
fix: get latest resource config before update

### DIFF
--- a/controllers/mergesource_controller.go
+++ b/controllers/mergesource_controller.go
@@ -94,6 +94,7 @@ func (r *MergeSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	return ctrl.Result{RequeueAfter: time.Minute}, nil
 }
 
+//nolint:funlen
 func (r *MergeSourceReconciler) reconcileMergeSource(
 	ctx context.Context, mergeSource *MergeSource, watched *watchedConfigMap,
 ) (bool, error) {


### PR DESCRIPTION
# Purpose

As part of load testing CMMC I ran into a couple of issues where `Update` calls to the `MergeSource` and target `ConfigMap` resources were erroring with an error like the following:

```
could not reconcile MergeSource: failed accumulating source: error updating watchedBy annotation on configMap: Operation cannot be fulfilled on configmaps "test-6168": the object has been modified; please apply your changes to the latest version and try again
```

or 

```
could not reconcile MergeSource: failed updating status after accumulating watched resources: Operation cannot be fulfilled on mergesources.config.cmmc.k8s.cash.app "aws-auth-map-roles": the object has been modified; please apply your changes to the latest version and try again
```

This issue doesn't really come up unless you have hundreds/thousands of ConfigMaps being watched. In local testing, this helped to resolve many errors when writing out thousands of ConfigMaps and the target MergeTarget was updated much more quickly.